### PR TITLE
AEROGEAR-8095 Increasing secret entropy 128 bits

### DIFF
--- a/src/main/java/org/jboss/aerogear/security/otp/api/Base32.java
+++ b/src/main/java/org/jboss/aerogear/security/otp/api/Base32.java
@@ -39,7 +39,7 @@ import java.util.Locale;
 public class Base32 {
     // singleton
 
-    private static final int SECRET_SIZE = 10;
+    private static final int SECRET_SIZE = 16;
 
     private static final SecureRandom RANDOM = new SecureRandom();
 

--- a/src/test/java/org/jboss/aerogear/security/otp/api/Base32Test.java
+++ b/src/test/java/org/jboss/aerogear/security/otp/api/Base32Test.java
@@ -25,11 +25,11 @@ public class Base32Test {
 
     @Test
     public void testRandom() throws Exception {
-        assertEquals(16, Base32.random().length());
+        assertEquals(26, Base32.random().length());
     }
 
     @Test
     public void testDecode() throws Exception {
-        assertEquals(10, Base32.decode(Base32.random()).length);
+        assertEquals(16, Base32.decode(Base32.random()).length);
     }
 }


### PR DESCRIPTION
## Motivation
An application I work on was flagged during a security audit for using 80 bit secrets for TOTP.  After looking into this project, I realized that the secret is 128 bits but is only based on 80 bits of entropy. RFC-4226 recommends a secret of at least 128 bits.

https://issues.jboss.org/browse/AEROGEAR-8095

## What
I increase the secret to 128-bits of entropy.

## Why
This was done to meet security requirements of RFC-4226.

## How
I increased the secret length to 128 bits prior to base32 encoding.

## Verification Steps
I believe the two unit test I updated verify this change.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress


## Additional Notes

 

